### PR TITLE
Fix: Force HFS+ filesystem for DMG to prevent unmountable disk images

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,10 @@
           ]
         }
       ],
+      "dmg": {
+        "filesystem": "HFS+",
+        "writeUpdateInfo": false
+      },
       "protocols": [
         {
           "name": "SpeakNative AI",


### PR DESCRIPTION
The DMGs were being created with APFS volumes but without proper GPT partition tables, making them unmountable on macOS. This is a common electron-builder issue when building unsigned apps.

Changes:
- Added dmg.filesystem: 'HFS+' to force HFS+ instead of APFS
- Added dmg.writeUpdateInfo: false (not using auto-updates yet)

This ensures:
- DMGs mount correctly with 'open' or double-click
- /Volumes/SpeakNativeAI appears when mounted
- Drag-and-drop installation works as expected

Root cause: electron-builder's APFS implementation requires code signing to work correctly. Since identity is null (unsigned), we need HFS+.

When you get Apple Developer enrollment, this config will still work and you can optionally switch back to APFS after adding signing.